### PR TITLE
Workaround for resolution in presentations

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -165,3 +165,9 @@ And then in `qmd`:
 ## Heading {background-iframe="./_example.html" background-interactive=true}
 ```
 
+Alternatively the `pixelScale` parameter can be used to upscale the resolution of the rendering in presentations
+and readjust for the 'downsampling' of `reveal.js`.
+```markdown
+{< mol-url ./www/7sgl.pdb pixelScale=3 >}
+```
+


### PR DESCRIPTION
Hi :)

While working on a presentation I found this workaround to improve the image quality of molstar in the reveal.js html file.

Instead of the complex `background iframe` one can simple use `pixelScale` to upscale the rendering and combat the down sampling in presentations.

Best,
Anton